### PR TITLE
OOP-60 Setup makefile for the application 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 node_modules
+.air.toml
+Backend/tmp
+tmp

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -42,10 +42,6 @@ The server will start on port 8080 by default.
 - `PUT /api/users/:id/deactivate` - Deactivate a user (requires authentication)
 - `PUT /api/users/:id/password` - Update a user's password (requires authentication)
 
-## Default Admin User
-
-Email: admin@example.com
-Password: admin123
 
 ## Development
 
@@ -57,6 +53,25 @@ Password: admin123
   - `handlers/` - HTTP handlers
   - `models/` - Data models
   - `repositories/` - Database operations
+
+### Makefile & Local Development
+
+Before you start, install Air for live-reloading your Go server:
+```bash
+go install github.com/air-verse/air@latest
+```
+A top-level `Makefile` is provided in the project root to simplify common tasks:
+
+- `make help`       — list available commands
+- `make back-dev`  — start backend dev server (Air)
+- `make front-dev` — start frontend dev server
+- `make dev`       — run both watchers in parallel
+
+Example:
+```bash
+make back-dev
+```
+Run `make help` for full list of targets.
 
 ### Running with Docker
 
@@ -93,4 +108,3 @@ docker run -it --rm \
   -e PORT=8080 \
   -v "$(pwd)/Backend":/app \
   backend-dev
-```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Makefile (project root)
+
+# variables
+BACKEND_DIR := Backend
+FRONTEND_DIR := Frontend
+IMAGE_NAME := backend-dev
+
+.PHONY: help dev back-dev back-build back-run front-dev front-build docker-build clean
+
+help:
+	@echo "❯ make dev         # start both backend+frontend watchers"
+	@echo "❯ make back-dev    # start backend (Air) in dev mode"
+	@echo "❯ make front-dev   # start frontend (e.g. vite/quasar) in dev"
+	@echo "❯ make back-build  # build backend binary"
+	@echo "❯ make front-build # build frontend for production"
+	@echo "❯ make docker-build  # build backend-dev Docker image"
+	@echo "❯ make clean       # remove tmp artifacts"
+
+dev:
+	@echo "Starting both backend and frontend watchers..."
+	$(MAKE) -j2 back-dev front-dev
+
+### backend tasks ###
+back-dev:
+	cd $(BACKEND_DIR) && air
+
+back-build:
+	cd $(BACKEND_DIR) && go build -o main ./cmd/web
+
+back-run:
+	cd $(BACKEND_DIR) && ./main
+
+### frontend tasks ###
+front-dev:
+	cd $(FRONTEND_DIR) && bun dev  # or `quasar dev` etc.
+
+front-build:
+	cd $(FRONTEND_DIR) && bun run build
+
+### docker ###
+docker-build:
+	docker build -f $(BACKEND_DIR)/Dockerfile -t $(IMAGE_NAME) .
+
+clean:
+	-rm -rf $(BACKEND_DIR)/tmp
+	-rm -rf $(FRONTEND_DIR)/dist


### PR DESCRIPTION
https://oopfinalscs22agroup3.atlassian.net/browse/OOP-60
faet: implemented makefile that starts either the frontend, backend or both.

- also updated the README to include the installation of air (live reload)
- added the built files to .gitignore and the .air.toml